### PR TITLE
feat: add base metrics endpoint

### DIFF
--- a/etc/hertzbeat-collector.yaml
+++ b/etc/hertzbeat-collector.yaml
@@ -33,3 +33,6 @@ collector:
   # Collector identity and mode
   identity: hertzbeat-collector-go
   mode: public
+
+  metrics:
+    port: 9090

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -18,3 +18,137 @@
  */
 
 package metrics
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	clrserver "hertzbeat.apache.org/hertzbeat-collector-go/internal/server"
+	"hertzbeat.apache.org/hertzbeat-collector-go/internal/types/collector"
+	"hertzbeat.apache.org/hertzbeat-collector-go/internal/util/logger"
+)
+
+const (
+	Namespace = "hertzbeat"
+	Subsystem = "collector"
+)
+
+var (
+	// JobExecutionTotal counts the total number of job executions
+	JobExecutionTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      "job_execution_total",
+			Help:      "Total number of job executions",
+		},
+		[]string{"status", "type"},
+	)
+
+	// JobExecutionDuration tracks the duration of job executions
+	JobExecutionDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      "job_execution_duration_seconds",
+			Help:      "Duration of job executions in seconds",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"type"},
+	)
+
+	// CollectorUp indicates if the collector is up
+	CollectorUp = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      "up",
+			Help:      "1 if the collector is up, 0 otherwise",
+		},
+	)
+)
+
+func init() {
+	// Register metrics with the global prometheus registry
+	prometheus.MustRegister(JobExecutionTotal)
+	prometheus.MustRegister(JobExecutionDuration)
+	prometheus.MustRegister(CollectorUp)
+	CollectorUp.Set(1)
+}
+
+// Runner implements the metrics server runner
+type Runner struct {
+	cfg    *clrserver.Server
+	server *http.Server
+}
+
+// New creates a new metrics runner
+func New(cfg *clrserver.Server) *Runner {
+
+	return &Runner{cfg: cfg}
+}
+
+// Start starts the metrics server
+func (r *Runner) Start(ctx context.Context) error {
+
+	// init logger
+	mlog := r.initLogs()
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+
+	addr := fmt.Sprintf(":%d", r.cfg.Config.Collector.MetricsConfig.Port)
+	r.server = &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadTimeout:       5 * time.Second,
+		ReadHeaderTimeout: 5 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       15 * time.Second,
+		MaxHeaderBytes:    1 << 20, // 1 MB
+		BaseContext: func(_ net.Listener) context.Context {
+			return ctx
+		},
+	}
+
+	mlog.Info("Starting metrics server", "addr", addr)
+
+	go func() {
+		if err := r.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			mlog.Error(err, "Metrics server failed")
+		}
+	}()
+
+	<-ctx.Done()
+	return r.Close()
+}
+
+// Info returns the runner info
+func (r *Runner) Info() collector.Info {
+
+	return collector.Info{
+		Name: "metrics-server",
+	}
+}
+
+// Close closes the metrics server
+func (r *Runner) Close() error {
+
+	if r.server != nil {
+		r.initLogs().Info("Shutting down metrics server")
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return r.server.Shutdown(ctx)
+	}
+	return nil
+}
+
+func (r *Runner) initLogs() logger.Logger {
+
+	return r.cfg.Logger.WithName("metrics")
+}

--- a/internal/types/config/config_types.go
+++ b/internal/types/config/config_types.go
@@ -22,11 +22,12 @@ type CollectorConfig struct {
 }
 
 type CollectorSection struct {
-	Info     CollectorInfo      `yaml:"info"`
-	Log      CollectorLogConfig `yaml:"log"`
-	Manager  ManagerConfig      `yaml:"manager"`
-	Identity string             `yaml:"identity"`
-	Mode     string             `yaml:"mode"`
+	Info          CollectorInfo      `yaml:"info"`
+	Log           CollectorLogConfig `yaml:"log"`
+	Manager       ManagerConfig      `yaml:"manager"`
+	Identity      string             `yaml:"identity"`
+	Mode          string             `yaml:"mode"`
+	MetricsConfig MetricsConfig      `yaml:"metrics"`
 	// todo dispatcher
 }
 
@@ -45,4 +46,9 @@ type ManagerConfig struct {
 	Host     string `yaml:"host"`
 	Port     string `yaml:"port"`
 	Protocol string `yaml:"protocol"`
+}
+
+type MetricsConfig struct {
+	// Others?
+	Port int `yaml:"port"`
 }


### PR DESCRIPTION
优化项：

hcg 中的组件（job transport & metrics）被设计成以 runner 的形式运行，从 cmd/server.go 通过 cfgServer 启动，各个子 runner 的私有属性不应该在 server 中被初始化，应该由子 runner 自己负责，server 只负责启动所有 runner 模块。实现依赖解耦